### PR TITLE
PAR-2516B: Fix Pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.1</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.parlio</groupId>
 	<artifactId>parse4j</artifactId>
-	<version>1.5-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>parse4j</name>
 	<url>https://github.com/Parlio/parse4j</url>
-
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
 
 	<licenses>
 		<license>


### PR DESCRIPTION
- Fixed change of modelVersion back to 4.0.0, this is the maven POM model.
- Upgraded version to 1.6
- removed parent repo, as there is no one currently for Parlio.
